### PR TITLE
Add initial mailhog-command

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,0 +1,16 @@
+.DS_Store
+.git
+.gitignore
+.gitlab-ci.yml
+.editorconfig
+.travis.yml
+behat.yml
+circle.yml
+bin/
+features/
+utils/
+*.zip
+*.tar.gz
+*.swp
+*.txt
+*.log

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,25 @@
+# This file is for unifying the coding style for different editors and IDEs
+# editorconfig.org
+
+# WordPress Coding Standards
+# https://make.wordpress.org/core/handbook/coding-standards/
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = tab
+
+[{.jshintrc,*.json,*.yml,*.feature}]
+indent_style = space
+indent_size = 2
+
+[{*.txt,wp-config-sample.php}]
+end_of_line = crlf
+
+[composer.json]
+indent_style = space
+indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -17,7 +17,7 @@ indent_style = tab
 indent_style = space
 indent_size = 2
 
-[{*.txt,wp-config-sample.php}]
+[{*.txt}]
 end_of_line = crlf
 
 [composer.json]

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+.DS_Store
+wp-cli.local.yml
+node_modules/
+vendor/
+*.zip
+*.tar.gz
+*.swp
+*.txt
+*.log
+composer.lock
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .DS_Store
-wp-cli.local.yml
 node_modules/
 vendor/
 *.zip

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,25 @@
+{
+    "name": "easyengine/mailhog-command",
+    "description": "Commanad to enable disable mailhog for sites.",
+    "type": "ee-cli-package",
+    "homepage": "https://github.com/easyengine/mailhog-command",
+    "license": "MIT",
+    "authors": [],
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "autoload": {
+        "psr-4": {
+            "": "src/"
+        },
+        "files": [ "mailhog-command.php" ]
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.x-dev"
+        },
+        "bundled": true,
+        "commands": [
+            "mailhog"
+        ]
+    }
+}

--- a/ee.yml
+++ b/ee.yml
@@ -1,0 +1,2 @@
+require:
+  - mailhog-command.php

--- a/mailhog-command.php
+++ b/mailhog-command.php
@@ -1,0 +1,12 @@
+<?php
+
+if ( ! class_exists( 'EE' ) ) {
+	return;
+}
+
+$autoload = dirname( __FILE__ ) . '/vendor/autoload.php';
+if ( file_exists( $autoload ) ) {
+	require_once $autoload;
+}
+
+EE::add_command( 'mailhog', 'Mailhog_Command' );

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,43 @@
+<?xml version="1.0"?>
+<ruleset name="EE">
+	<description>WordPress Coding Standards for EE</description>
+
+	<!-- Show sniff codes in all reports, and progress while running -->
+	<arg value="sp"/>
+	<!-- Check all PHP files in directory tree by default. -->
+	<arg name="extensions" value="php"/>
+	<!-- Run different reports -->
+	<arg name="report" value="full"/>
+	<arg name="report" value="summary"/>
+	<arg name="report" value="source"/>
+
+	<file>.</file>
+	<exclude-pattern>*/ci/*</exclude-pattern>
+	<exclude-pattern>*/features/*</exclude-pattern>
+	<exclude-pattern>*/packages/*</exclude-pattern>
+	<exclude-pattern>*/tests/*</exclude-pattern>
+	<exclude-pattern>*/utils/*</exclude-pattern>
+	<exclude-pattern>*/vendor/*</exclude-pattern>
+
+	<rule ref="PHPCompatibility">
+		<!-- Polyfill package is used so array_column() is available for PHP 5.4- -->
+		<exclude name="PHPCompatibility.PHP.NewFunctions.array_columnFound"/>
+		<!-- Both magic quotes directives set in wp-settings-cli.php to provide consistent starting point. -->
+		<exclude name="PHPCompatibility.PHP.DeprecatedIniDirectives.magic_quotes_runtimeDeprecatedRemoved"/>
+		<exclude name="PHPCompatibility.PHP.DeprecatedIniDirectives.magic_quotes_sybaseDeprecatedRemoved"/>
+	</rule>
+	<config name="testVersion" value="7.0-"/>
+
+	<rule ref="WordPress-Core">
+		<exclude name="Squiz.PHP.DisallowMultipleAssignments.Found" />
+		<exclude name="WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar" />
+		<exclude name="WordPress.NamingConventions.ValidVariableName.MemberNotSnakeCase" />
+		<exclude name="WordPress.NamingConventions.ValidVariableName.NotSnakeCase" />
+	</rule>
+	<rule ref="WordPress.Files.FileName">
+		<properties>
+			<property name="strict_class_file_names" value="false"/>
+		</properties>
+		<exclude name="WordPress.Files.FileName.NotHyphenatedLowercase" />
+	</rule>
+</ruleset>

--- a/src/Mailhog_Command.php
+++ b/src/Mailhog_Command.php
@@ -1,0 +1,108 @@
+<?php
+
+/**
+ * Enables/Disables admin-tools on a site.
+ *
+ * ## EXAMPLES
+ *
+ *     # Enable admin tools on site
+ *     $ ee admin-tools up example.com
+ *
+ * @package ee-cli
+ */
+
+use \Symfony\Component\Filesystem\Filesystem;
+
+class Mailhog_Command extends EE_Command {
+
+	/**
+	 * @var array $site Associative array containing essential site related information.
+	 */
+	private $site;
+
+	/**
+	 * Enables mailhog on given site.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [<site-name>]
+	 * : Name of website to enable mailhog on.
+	 */
+	public function up( $args, $assoc_args ) {
+
+		EE\Utils\delem_log( 'mailhog' . __FUNCTION__ . ' start' );
+		$args = EE\SiteUtils\auto_site_name( $args, 'mailhog', __FUNCTION__ );
+		$this->populate_site_info( $args );
+		chdir( $this->site['root'] );
+
+		// TODO: mailhog_enabled fnuction after db changes
+		// if($this->mailhog_enabled()){
+		// 	EE::error('Mailhog is already enabled.');
+		// }
+
+		chdir( $this->site['root'] );
+		$this->check_mailhog_available();
+		EE::docker()::docker_compose_up( $this->site['root'], [ 'mailhog' ] );
+		EE::exec( "docker-compose exec postfix postconf -e 'relayhost = mailhog:1025'" );
+
+	}
+
+	/**
+	 * Disables mailhog on given site.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [<site-name>]
+	 * : Name of website to disable mailhog on.
+	 */
+	public function down( $args, $assoc_args ) {
+
+		EE\Utils\delem_log( 'mailhog' . __FUNCTION__ . ' start' );
+		$args = EE\SiteUtils\auto_site_name( $args, 'mailhog', __FUNCTION__ );
+		$this->populate_site_info( $args );
+
+		// TODO: mailhog_enabled fnuction after db changes
+		// if($this->mailhog_enabled()){
+		// 	Then only run this...
+		// }
+
+		chdir( $this->site['root'] );
+		$this->check_mailhog_available();
+		EE::docker()::stop_container( 'mailhog' );
+		EE::exec( 'docker-compose exec postfix postconf -e \'relayhost =\'' );
+
+	}
+
+	/**
+	 * Function to check if mailhog is present in docker-compose.yml or not.
+	 */
+	private function check_mailhog_available() {
+		$launch   = EE::launch( 'docker-compose config --services' );
+		$services = explode( PHP_EOL, trim( $launch->stdout ) );
+		if ( ! in_array( 'mailhog', $services, true ) ) {
+			EE::debug( 'Site type: ' . $this->site['type'] );
+			EE::debug( 'Site command: ' . $this->site['command'] );
+			EE::error( sprintf( '%s site does not have support to enable/disable mailhog.' ) );
+		}
+	}
+
+	/**
+	 * Populate basic site info from db.
+	 */
+	private function populate_site_info( $args ) {
+
+		$this->site['name'] = EE\Utils\remove_trailing_slash( $args[0] );
+
+		if ( EE::db()::site_in_db( $this->site['name'] ) ) {
+
+			$db_select = EE::db()::select( [], [ 'sitename' => $this->site['name'] ], 'sites', 1 );
+
+			$this->site['type']    = $db_select['site_type'];
+			$this->site['root']    = $db_select['site_path'];
+			$this->site['command'] = $db_select['site_command'];
+		} else {
+			EE::error( sprintf( 'Site %s does not exist.', $this->site['name'] ) );
+		}
+	}
+
+}

--- a/src/Mailhog_Command.php
+++ b/src/Mailhog_Command.php
@@ -16,9 +16,9 @@ use \Symfony\Component\Filesystem\Filesystem;
 class Mailhog_Command extends EE_Command {
 
 	/**
-	 * @var array $site Associative array containing essential site related information.
+	 * @var array $db Object containing essential site related information.
 	 */
-	private $site;
+	private $db;
 
 	/**
 	 * Enables mailhog on given site.
@@ -32,17 +32,19 @@ class Mailhog_Command extends EE_Command {
 
 		EE\Utils\delem_log( 'mailhog' . __FUNCTION__ . ' start' );
 		$args = EE\SiteUtils\auto_site_name( $args, 'mailhog', __FUNCTION__ );
-		$this->populate_site_info( $args );
-		chdir( $this->site['root'] );
+		$this->db = Site::find( EE\Utils\remove_trailing_slash( $args[0] ) );
+		if ( ! $this->db || ! $this->db->site_enabled ) {
+			EE::error( sprintf( 'Site %s does not exist / is not enabled.', $args[0] ) );
+		}
 
 		// TODO: mailhog_enabled fnuction after db changes
 		// if($this->mailhog_enabled()){
 		// 	EE::error('Mailhog is already enabled.');
 		// }
 
-		chdir( $this->site['root'] );
+		chdir( $this->db->site_fs_path );
 		$this->check_mailhog_available();
-		EE::docker()::docker_compose_up( $this->site['root'], [ 'mailhog' ] );
+		EE::docker()::docker_compose_up( $this->db->site_fs_path, [ 'mailhog' ] );
 		EE::exec( "docker-compose exec postfix postconf -e 'relayhost = mailhog:1025'" );
 
 	}
@@ -59,14 +61,16 @@ class Mailhog_Command extends EE_Command {
 
 		EE\Utils\delem_log( 'mailhog' . __FUNCTION__ . ' start' );
 		$args = EE\SiteUtils\auto_site_name( $args, 'mailhog', __FUNCTION__ );
-		$this->populate_site_info( $args );
+		$this->db = Site::find( EE\Utils\remove_trailing_slash( $args[0] ) );
+		if ( ! $this->db || ! $this->db->site_enabled ) {
+			EE::error( sprintf( 'Site %s does not exist / is not enabled.', $args[0] ) );
+		}
 
 		// TODO: mailhog_enabled fnuction after db changes
 		// if($this->mailhog_enabled()){
 		// 	Then only run this...
 		// }
 
-		chdir( $this->site['root'] );
 		$this->check_mailhog_available();
 		EE::docker()::stop_container( 'mailhog' );
 		EE::exec( 'docker-compose exec postfix postconf -e \'relayhost =\'' );
@@ -77,31 +81,14 @@ class Mailhog_Command extends EE_Command {
 	 * Function to check if mailhog is present in docker-compose.yml or not.
 	 */
 	private function check_mailhog_available() {
+
+		chdir( $this->db->site_fs_path );
 		$launch   = EE::launch( 'docker-compose config --services' );
 		$services = explode( PHP_EOL, trim( $launch->stdout ) );
 		if ( ! in_array( 'mailhog', $services, true ) ) {
-			EE::debug( 'Site type: ' . $this->site['type'] );
-			EE::debug( 'Site command: ' . $this->site['command'] );
+			EE::debug( 'Site type: ' . $this->db->site_type );
+			EE::debug( 'Site command: ' . $this->db->app_sub_type );
 			EE::error( sprintf( '%s site does not have support to enable/disable mailhog.' ) );
-		}
-	}
-
-	/**
-	 * Populate basic site info from db.
-	 */
-	private function populate_site_info( $args ) {
-
-		$this->site['name'] = EE\Utils\remove_trailing_slash( $args[0] );
-
-		if ( EE::db()::site_in_db( $this->site['name'] ) ) {
-
-			$db_select = EE::db()::select( [], [ 'sitename' => $this->site['name'] ], 'sites', 1 );
-
-			$this->site['type']    = $db_select['site_type'];
-			$this->site['root']    = $db_select['site_path'];
-			$this->site['command'] = $db_select['site_command'];
-		} else {
-			EE::error( sprintf( 'Site %s does not exist.', $this->site['name'] ) );
 		}
 	}
 


### PR DESCRIPTION
Depends on: https://github.com/EasyEngine/easyengine/pull/1163
Depends on: https://github.com/EasyEngine/site-wp-command/issues/7
Depends on: https://github.com/EasyEngine/easyengine/pull/1143

Closes https://github.com/EasyEngine/site-wp-command/issues/7

Add support for:

```
ee mailhog up <site-name>
ee mailhog down <site-name>
ee mailhog status <site-name>
```

Signed-off-by: Riddhesh Sanghvi <riddheshsanghvi96@gmail.com>